### PR TITLE
Fix a small issue on get_contents method

### DIFF
--- a/lib/pkgwat.rb
+++ b/lib/pkgwat.rb
@@ -24,6 +24,7 @@ module Pkgwat
   BUGZILLA_RELEASEA = ["all" => "", "building" =>"0", "success" => "1", "failed" => "2", "cancelled" => "3", "deleted" => "4"]
   BODHI_REALEASE = ["all", "f17", "f16", "f15", "e16", "e15"]
   BODHI_ARCH = ["x86_64", "i686"]
+
   def self.check_gem(name, version, distros = DEFAULT_DISTROS, throw_ex = false)
     puts "Checking #{name} #{version}...\n"
     versions = get_versions(name)


### PR DESCRIPTION
If a user puts an unexpected value as a release or an arch we would face an issue, Fedora package api will return a 500 error so the result will be very confused.
