### PR TITLE
loosen dependencies on json, nokogiri, minitest

### DIFF
--- a/pkgwat.gemspec
+++ b/pkgwat.gemspec
@@ -15,15 +15,15 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "pkgwat"
 
-  s.add_dependency("nokogiri", "1.6.0")
+  s.add_dependency("nokogiri")
   s.add_dependency("rake")
   s.add_dependency("thor")
-  s.add_dependency("json", "1.8.0")
+  s.add_dependency("json")
   s.add_dependency("sanitize")
 
   s.add_development_dependency("vcr", "~> 2.4.0")
   s.add_development_dependency("webmock", "~> 1.9.0")
-  s.add_development_dependency("minitest", "~> 4.4.0")
+  s.add_development_dependency("minitest", "~> 4.0")
   if RUBY_VERSION >= "1.9"
     s.add_development_dependency("debugger")
   else


### PR DESCRIPTION
It's too hard to chase the versions for json and nokogiri. This pull request removes the version numbers for these gems altogether. For minitest, the pull request relaxes the dependency to versions 4.x.

This also allows us to load the Gem using Fedora's system libs.
