### PR TITLE
gracefully handle missing debugger gem

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,12 @@ ENV['RACK_ENV'] = 'test'
 require 'minitest/autorun'
 require 'pkgwat'
 require 'vcr'
-require 'debugger'
+begin
+  require 'debugger'
+rescue LoadError
+  warn "warning: debugger gem not found; skipping debugger support"
+end
+
 
 mode = ENV['mode'] ? ENV['mode'] : :none
 


### PR DESCRIPTION
Debugger is not yet packaged for Fedora. If we do not have debugger installed, we should be able to continue with the rest of the test suite.

Tested on Fedora 19, ruby 2.0.0p247 (2013-06-27 revision 41674) [i386-linux]
