### PR TITLE
fix grammar in summary

### DIFF
--- a/pkgwat.gemspec
+++ b/pkgwat.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.authors     = ["David Davis"]
   s.email       = ["daviddavis@redhat.com"]
   s.homepage    = "https://github.com/daviddavis/pkgwat"
-  s.summary     = %q{pkgwat checks your gems to against Fedora/EPEL.}
+  s.summary     = %q{pkgwat checks your gems against Fedora/EPEL.}
   s.description = %q{pkgwat checks your Gemfile.lock to make sure all your gems
                      are packaged in Fedora/EPEL. Eventually we hope to support
                      Gemfiles and bundle list as well.}


### PR DESCRIPTION
This pull request fixes a small grammatical error in the summary metadata in pkgwat's gemspec.
