### PR TITLE
is thor a valid requirement?

### DIFF
--- a/pkgwat.gemspec
+++ b/pkgwat.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency("nokogiri", "~> 1.4")
   s.add_dependency("rake")
-  s.add_dependency("thor")
   s.add_dependency("json", "~> 1.4")
   s.add_dependency("sanitize")
 


### PR DESCRIPTION
thor is listed as a dependency in pkgwat.gemspec, but I don't see it used anywhere in the code, past or present. Could we remove it from the gemspec?
